### PR TITLE
docker-composeファイルにmysqlを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,23 @@
-version: "3.8"
+version: '3.8'
 services:
   api:
     build: .
     tty: true
     ports:
-      - "3000:3000"
+      - '3000:3000'
     volumes:
       - type: bind
         source: .
         target: /api
+  mysql:
+    image: mysql:8
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: develop
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    volumes:
+      - /var/lib/mysql


### PR DESCRIPTION
docker-composeファイルにmysql8系を追加した
mikroORMは8系をサポートしてるっぽい